### PR TITLE
Example Status Field Hook

### DIFF
--- a/ExampleStatusFieldHook.php
+++ b/ExampleStatusFieldHook.php
@@ -11,6 +11,8 @@ use Symfony\Component\Console\Event\ConsoleCommandEvent;
 /**
  * This hook file demonstrates how to add a new line to the drush
  * core:status command.
+ *
+ * Note that this hook requires Drush 9; it does not work in Drush 8.
  */
 class ExampleStatusFieldHook extends DrushCommands
 {

--- a/ExampleStatusFieldHook.php
+++ b/ExampleStatusFieldHook.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drush\Commands\example_drush_extension;
+
+use Consolidation\AnnotatedCommand\AnnotationData;
+use Consolidation\AnnotatedCommand\CommandData;
+use Consolidation\OutputFormatters\Options\FormatterOptions;
+use Drush\Commands\DrushCommands;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+
+/**
+ * This hook file demonstrates how to add a new line to the drush
+ * core:status command.
+ */
+class ExampleStatusFieldHook extends DrushCommands
+{
+    /**
+     * Add a new default field, 'example-status' to the core:status command.
+     *
+     * Without this hook, the 'example-status' field will be added to the
+     * output result, but it will not be displayed unless requested, e.g.
+     * via `--fields=*` or `--field=example-status`.
+     *
+     * Note that an alter hook is needed to actually add the field to the
+     * core:status command output. Without the alter hook, this hook will
+     * cause an error.
+     * @see addCoreStatusField()
+     *
+     * @hook command-event core:status
+     */
+    public function addCoreStatusDefaultField(ConsoleCommandEvent $event) {
+        // gets the command to be executed
+        $command = $event->getCommand();
+        $definition = $command->getDefinition();
+        $options = $definition->getOptions();
+
+        $default_fields = $options['fields']->getDefault();
+        $default_fields .= ',example-status';
+        $options['fields']->setDefault($default_fields);
+    }
+
+    /**
+     * Add an 'example-status' field to the core:status command.
+     *
+     * Note that a command-event hook is necessary to make this field be
+     * displayed by default in the `drush core:status` command.
+     * @see addCoreStatusDefaultField()
+     *
+     * @hook alter core:status
+     */
+    public function addCoreStatusField($result, CommandData $commandData)
+    {
+        $formatter_options = $commandData->formatterOptions();
+        // Add a field label for our new 'whoami' field. This is required
+        // in order for this field to be selectable; otherwise, our structured
+        // data formatters will remove it.
+        $field_labels = $formatter_options->get(FormatterOptions::FIELD_LABELS);
+        $field_labels['example-status'] = 'Example Status';
+        $formatter_options->setFieldLabels($field_labels);
+
+        // Add our data to the new example field.
+        $result['example-status'] = 'Added by ' . __METHOD__;
+
+        return $result;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -62,4 +62,5 @@ Customizing
 2. Alter "name", "description" and etc. in composer.json to suit.
 3. Rename ExampleCommands.php and ExampleCommandsTest.php for your project.
 4. Configuration and site aliases for use in testing can be placed in 'sut/drush/drush.yml' and 'sut/drush/sites/self.site.yml', respectively.
-5. Add your extension on packagist.org so that it may be installed via Composer.
+5. Examine 'sut/drush/drush.yml' and 'sut/drush/drushrc.php', and alter the names of the example command files to match the names in your project. This is necessary for Drush to be able to find your command files when running tests or doing ad-hoc testing, as usually, command files are searched for in the parent directory of the project root.
+6. Add your extension on packagist.org so that it may be installed via Composer.

--- a/sut/drush/drush.yml
+++ b/sut/drush/drush.yml
@@ -6,6 +6,7 @@
 drush:
   commands:
     '\Drush\Commands\example_drush_extension\ExampleCommands': '${env.cwd}/ExampleCommands.php'
+    '\Drush\Commands\example_drush_extension\ExampleStatusFieldHook': '${env.cwd}/ExampleStatusFieldHook.php'
 
 example:
   # Used in testExampleConfiguration in tests/DrushExtensionTest.php

--- a/sut/drush/drushrc.php
+++ b/sut/drush/drushrc.php
@@ -3,8 +3,10 @@
 // Add our commandfile into the cached commandfile context. Only do this for testing.
 $drush_extension_namespace = '\\Drush\\Commands\\example_drush_extension\\ExampleCommands';
 $drush_extension_filepath = dirname(dirname(__DIR__)) . '/ExampleCommands.php';
+$drush_hook_filepath = dirname(dirname(__DIR__)) . '/ExampleStatusFieldHook.php';
 $annotation_commandfiles = drush_get_context('DRUSH_ANNOTATED_COMMANDFILES');
 $annotation_commandfiles[$drush_extension_filepath] = $drush_extension_namespace;
+$annotation_commandfiles[$drush_hook_filepath] = $drush_extension_namespace;
 drush_set_context('DRUSH_ANNOTATED_COMMANDFILES', $annotation_commandfiles);
 
 // Used in testExampleConfiguration in tests/DrushExtensionTest.php

--- a/tests/ExampleStatusFieldHookTest.php
+++ b/tests/ExampleStatusFieldHookTest.php
@@ -6,11 +6,11 @@ use Drush\TestTraits\DrushTestTrait;
 use TestUtils\FixturesTrait;
 
 /**
- * This example test does not exercise our Drush extension at all; its
- * only purpose is to demonstrate how to use the fixtures class to install
- * Drupal so that a command that requires a full bootstrap may be tested.
+ * This test does a full bootstrap of our Drupal site-under-test,
+ * and then tests to see if our example status field hook successfully
+ * added the 'example-status' field to the `drush core:status` command.
  */
-class BootstrapDrupalTest extends TestCase
+class ExampleStatusFieldHookTest extends TestCase
 {
     use FixturesTrait;
 
@@ -34,5 +34,6 @@ class BootstrapDrupalTest extends TestCase
         $json = $this->getOutputFromJSON();
         $this->assertEquals('Successful', $json['bootstrap']);
         $this->assertEquals('Connected', $json['db-status']);
+        $this->assertEquals('Added by Drush\Commands\example_drush_extension\ExampleStatusFieldHook::addCoreStatusField', $json['example-status']);
     }
 }

--- a/tests/ExampleStatusFieldHookTest.php
+++ b/tests/ExampleStatusFieldHookTest.php
@@ -30,7 +30,9 @@ class ExampleStatusFieldHookTest extends TestCase
      */
     public function testDrushStatus()
     {
-        if (DRUSH_MAJOR_VERSION == '8') {
+        $this->drush('version', [], ['format' => 'string']);
+        $version = $this->getOutput();
+        if ($version[0] == '8') {
             $this->markTestSkipped('Status field injection only works in Drush 9+');
         }
 

--- a/tests/ExampleStatusFieldHookTest.php
+++ b/tests/ExampleStatusFieldHookTest.php
@@ -30,6 +30,10 @@ class ExampleStatusFieldHookTest extends TestCase
      */
     public function testDrushStatus()
     {
+        if (DRUSH_MAJOR_VERSION == '8') {
+            $this->markTestSkipped('Status field injection only works in Drush 9+');
+        }
+
         $this->drush('status', [], ['format' => 'json']);
         $json = $this->getOutputFromJSON();
         $this->assertEquals('Successful', $json['bootstrap']);


### PR DESCRIPTION
Add an example hook to demonstrate the insertion of an extra line in the output of the core:status command.